### PR TITLE
Enable default Skipdata behavior

### DIFF
--- a/capstr.go
+++ b/capstr.go
@@ -57,6 +57,7 @@ func New(arch, mode int) (*Engine, error) {
 		return nil, CsError(cserr)
 	}
 	C.cs_option(handle, C.CS_OPT_DETAIL, C.CS_OPT_OFF)
+	C.cs_option(handle, C.CS_OPT_SKIPDATA, C.CS_OPT_ON)
 	return &Engine{handle}, nil
 }
 


### PR DESCRIPTION
In this mode data (or invalid instructions) will be skipped and
the disassembly will attempt continue. Prior to this change, it aborts.

In the default Skipdata mode of operation, the number of bytes skipped
is based upon the architecture and mode. Skipped data is included in the
disassembly as a sequence of byte, prefixed by the Capstone
SKIPDATA_MNEM mnemonic (".byte" at the time of writing).