### PR TITLE
README: Fix usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Usage
 import "github.com/lunixbochs/capstr"
 
 engine, err := capstr.New(capstr.ARCH_X86, capstr.MODE_32)
-for _, ins := range engine.Dis(code, addr, insCount) {
+insns, err := engine.Dis(code, addr, insCount)
+for _, ins := range insns {
     fmt.Printf("%#x: %s %s\n", ins.Addr(), ins.Mnemonic(), ins.OpStr())
 }
 ```


### PR DESCRIPTION
`Dis` returns an error along with the slice of instructions, so you can't use it with `range` directly.